### PR TITLE
fix cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.scripts]
-springtime = "springtime.main:main"
+springtime = "springtime.main:cli"
 
 [project.urls]
 Documentation = "https://github.com/phenology/springtime#readme"


### PR DESCRIPTION
Makes this command work:

`hatch run springtime tests/recipes/pyphenology.yaml`

If you already had a hatch environment, you need to remove it first with `hatch env remove`

closes #43 