### PR TITLE
Fix hatch options

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,6 @@ jobs:
         python -m pip install hatch
     - name: Run checks
       run: |
-        hatch run dev:ruff check src
-        hatch run dev:mypy src tests
-        hatch run dev:reuse lint
+        hatch run ruff check src
+        hatch run mypy src tests
+        hatch run reuse lint

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,13 @@ build:
   tools:
     python: "3.9"
 
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
 mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
-
-python:
-   install:
-   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: 2023 Springtime authors
-#
-# SPDX-License-Identifier: Apache-2.0
-
-mkdocs>=1.4.2
-mkdocs-material>=8.0.0,<9.0.0
-mkdocs-jupyter>=0.22.0
-mkdocs-gen-files
-mkdocs-include-markdown-plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2023 Springtime authors
-#
-# SPDX-License-Identifier: Apache-2.0
-
 [build-system]
 requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"
@@ -42,12 +38,31 @@ dependencies = [
   "pandas",
   "pydantic",
   "click",
-  "rpy2",
   "geopandas",
   "dask",  # needed for xarray.open_mfdataset()
   "netCDF4",
 ]
-dynamic = ["version", "optional-dependencies"]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+r = [
+  "rpy2",
+]
+dev = [
+  "black",
+  "mypy",
+  "pytest",
+  "reuse",
+  "ruff",
+  "types-pyyaml", # https://github.com/python/mypy/issues/10632
+]
+docs = [
+  "mkdocs>=1.4.2",
+  "mkdocs-material>=8.0.0,<9.0.0",
+  "mkdocs-jupyter>=0.22.0",
+  "mkdocs-gen-files",
+  "mkdocs-include-markdown-plugin",
+]
 
 [project.urls]
 Documentation = "https://github.com/phenology/springtime#readme"
@@ -60,23 +75,8 @@ springtime = "springtime.main:cli"
 [tool.hatch.version]
 path = "src/springtime/__init__.py"
 
-[tool.hatch.metadata.hooks.requirements_txt.optional-dependencies]
-docs = ["docs/requirements.txt"]
-
-[tool.hatch.envs.dev]
-detached = true
-dependencies = [
-  "black",
-  "mypy",
-  "pytest",
-  "reuse",
-  "ruff",
-  "types-pyyaml", # https://github.com/python/mypy/issues/10632
-]
-
 [tool.hatch.envs.default]
-features = ["docs"]
-template = "dev"
+features = ["r", "dev", "docs"]
 
 [tool.hatch.envs.default.scripts]
 quality-checks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Springtime authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["hatchling", "hatch-requirements-txt"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
This PR changes some installation options, because

- Mixing optional dependencies via import and via `['project.optional-dependencies']` doesn't work
- Mixing detached environment with optional dependencies doesn't work well
- Can't find a way to activate [detached environments](https://hatch.pypa.io/latest/config/environment/overview/#detached-environments) on ReadTheDocs