### PR TITLE
Update crib.md

### DIFF
--- a/docs/crib.md
+++ b/docs/crib.md
@@ -11,30 +11,32 @@ don't manage, you can add your own environment by making a new (conda or
 virtualenv) environment, and adding it to the Jupyter kernelspec list. To this end:
 
 ```bash
+# 0. Start Intel x86_64 machine
+
 # 1. Make sure you have mamba
 which mamba  # should return a path
 
+# If not install mambaforge and activate it
+
+# 2. Clone sprintime repo
+git clone https://github.com/phenology/springtime.git
+cd springtime
+
 # 2. Create new environment
-mamba create -n springtime python=3.9 ipykernel
+mamba env create --file environment.yml
 
 # 3. Activate the environment
 mamba activate springtime
 
-# 4a. Install default springtime inside the environment
-pip install git+https://github.com/phenology/springtime.git
-
-# 4b. Developer installation
-git clone git@github.com:phenology/springtime
-cd springtime
+# 4. Developer installation
 pip install -e .
 
-# 5. Possibly, use a custom start-kernel.sh script
+# 5. Add Jupyter kernel
 # See the instructions here: https://github.com/ESMValGroup/ESMValTool-JupyterLab#using-a-custom-kernel-script
+pip install ipykernel
+python -m ipykernel install --user --name springtime_x86 --display-name="Springtime x86"
 
-# 6. Possibly, if there is no, or you cannot use the default system R, you can
-#    install it inside the conda environment:
-mamba install r-base
-
+# 6. Install direct R dependencies
 # Enter an interactive R shell
 R
 


### PR DESCRIPTION
Do not use aarch64 as conda does not have all packages for that architecture. Use x86_64 intel instead.