### PR TITLE
Implement point-wise selection using xarray for EOBSMultiplePoints

### DIFF
--- a/src/springtime/datasets/e_obs.py
+++ b/src/springtime/datasets/e_obs.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import xarray as xr
 from itertools import product
 from typing import Literal, Sequence, Tuple
 from urllib.request import urlretrieve
@@ -165,9 +166,12 @@ class EOBSMultiplePoints(EOBS):
 
     def load(self):
         ds = super().load()
+        #pointwise selection
+        lons = xr.DataArray([p[0] for p in self.points], dims='points')
+        lats = xr.DataArray([p[1] for p in self.points], dims='points')
         return ds.sel(
-            longitude=[p[0] for p in self.points],
-            latitude=[p[1] for p in self.points],
+            longitude=lons,
+            latitude=lats,
             method="nearest",
         ).to_dataframe()
 
@@ -182,7 +186,7 @@ class EOBSBoundingBox(EOBS):
 
     dataset: Literal["EOBSBoundingBox"] = "EOBSBoundingBox"
     box: Tuple[float, float, float, float]
-    """Bounding box as top left / bottom right pair (lat,lon,lat,lon) 
+    """Bounding box as top left / bottom right pair (lat,lon,lat,lon)
     aka north,west,south,east in WGS84 projection.
     """
 

--- a/src/springtime/datasets/e_obs.py
+++ b/src/springtime/datasets/e_obs.py
@@ -166,9 +166,9 @@ class EOBSMultiplePoints(EOBS):
 
     def load(self):
         ds = super().load()
-        #pointwise selection
-        lons = xr.DataArray([p[0] for p in self.points], dims='points')
-        lats = xr.DataArray([p[1] for p in self.points], dims='points')
+        # pointwise selection
+        lons = xr.DataArray([p[0] for p in self.points], dims="points")
+        lats = xr.DataArray([p[1] for p in self.points], dims="points")
         return ds.sel(
             longitude=lons,
             latitude=lats,


### PR DESCRIPTION
closes #76

The fix is based on `xarray` doc https://docs.xarray.dev/en/stable/user-guide/indexing.html
see this [post](https://stackoverflow.com/questions/55034347/extract-interpolated-values-from-a-2d-array-based-on-a-large-set-of-xy-points/55034427#55034427) for more.

If 2 coordinates and 1 year are passed to `EOBSMultiplePoints`, `dataset.load()` returns a dataframe where `latitude, longitude, time` are indices and the size is `(2*2)*1*365`. 

Now `dataset.load()` returns a dataframe where `points, time` are indices, `latitude, longitude` are columns, and the size is `(2)*1*365`. This size is correct.
