### PR TITLE
Dockerdocs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,8 @@ jobs:
         micromamba-version: '1.4.6-0'  # 1.4.7 has a bug
         cache-environment: true
         environment-file: environment.yml
+        create-args: >-
+          python=3.10
     - name: Install R dependencies
       run: |
         Rscript -e 'devtools::install_github("bluegreen-labs/phenor", upgrade="never")'

--- a/.github/workflows/recipe.yml
+++ b/.github/workflows/recipe.yml
@@ -4,7 +4,7 @@
 
 name: Run test recipe
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       recipe:
@@ -24,7 +24,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Conda environment from environment.yml
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        micromamba-version: '1.4.6-0'  # 1.4.7 has a bug
+        cache-environment: true
+        environment-file: environment.yml
+        create-args: >-
+          python=3.10
     - name: Install R dependencies
       run: |
         Rscript -e 'install.packages(c("daymetr", "rnpn"), repos = "http://cran.us.r-project.org")'

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN Rscript -e 'install.packages(c("daymetr", "MODISTools", "phenocamr", "rnpn")
 
 # Copy repo and install package
 WORKDIR /home/jovyan
-COPY --chown=${NB_UID}:${NB_GID} . .
-RUN pip install -e .[r]
+COPY --chown=${NB_UID}:${NB_GID} . springtime
+RUN pip install -e ./springtime[r]
 
 # Add label to link to repo
 LABEL org.opencontainers.image.source https://github.com/phenology/springtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM --platform=amd64 mambaorg/micromamba:1.4.6
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/env.yaml
+RUN micromamba install -y -n base -f /tmp/env.yaml && \
+    micromamba clean --all --yes
+
+# Make sure the conda environment is activated for the remaining build
+# instructions below
+ARG MAMBA_DOCKERFILE_ACTIVATE=1  # (otherwise python will not be found)
+
+WORKDIR /repo
+COPY . .
+RUN pip install .[r]
+
+RUN Rscript -e 'devtools::install_github("bluegreen-labs/phenor", upgrade="never")'
+RUN Rscript -e 'devtools::install_github("ropensci/rppo", upgrade="never")'
+RUN Rscript -e 'install.packages(c("daymetr", "MODISTools", "phenocamr", "rnpn"), repos = "http://cran.us.r-project.org")'
+
+# To add to an existing jupyterhub
+RUN pip install ipykernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Springtime authors
+#
+# SPDX-License-Identifier: Apache-2.0
 FROM --platform=amd64 jupyter/r-notebook:python-3.10
 
 # Most springtime dependencies can be added from conda channels

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
-FROM --platform=amd64 mambaorg/micromamba:1.4.6
+FROM --platform=amd64 jupyter/r-notebook:python-3.10
 
-COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/env.yaml
-RUN micromamba install -y -n base -f /tmp/env.yaml && \
-    micromamba clean --all --yes
+# Most springtime dependencies can be added from conda channels
+COPY --chown=${NB_UID}:${NB_GID} environment.yml /tmp/
+RUN mamba env update --name base --file /tmp/environment.yml &&\
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
 
-# Make sure the conda environment is activated for the remaining build
-# instructions below
-ARG MAMBA_DOCKERFILE_ACTIVATE=1  # (otherwise python will not be found)
-
-WORKDIR /repo
-COPY . .
-RUN pip install .[r]
-
+# Additional R dependencies not available on conda channels
 RUN Rscript -e 'devtools::install_github("bluegreen-labs/phenor", upgrade="never")'
 RUN Rscript -e 'devtools::install_github("ropensci/rppo", upgrade="never")'
 RUN Rscript -e 'install.packages(c("daymetr", "MODISTools", "phenocamr", "rnpn"), repos = "http://cran.us.r-project.org")'
 
-# To add to an existing jupyterhub
-RUN pip install ipykernel
+# Copy repo and install package
+WORKDIR /home/jovyan
+COPY --chown=${NB_UID}:${NB_GID} . .
+RUN pip install -e .[r]
 
+# Add label to link to repo
 LABEL org.opencontainers.image.source https://github.com/phenology/springtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,5 @@ RUN Rscript -e 'install.packages(c("daymetr", "MODISTools", "phenocamr", "rnpn")
 
 # To add to an existing jupyterhub
 RUN pip install ipykernel
+
+LABEL org.opencontainers.image.source https://github.com/phenology/springtime

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ SPDX-License-Identifier: Apache-2.0
 [![RSD](https://img.shields.io/badge/RSD-springtime-blue)](https://research-software-directory.org/software/springtime)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7835299.svg)](https://doi.org/10.5281/zenodo.7835299)
 
+For detailed information and instruction, please refer to the
+[documentation](https://springtime.readthedocs.io/)
 
 <!--intro-start-->
 # Springtime
@@ -25,110 +27,12 @@ With Springtime, we aim to provide a more streamlined workflow for working with
 a variety of datasets and (ML) models. You can run Springtime as a command line
 tool in a terminal or use it as a Python library e.g. in a Jupyter notebook.
 
-<!--intro-end-->
-
-For more information and instruction, please refer to the
-[documentation](https://springtime.readthedocs.io/)
-
-
-<!--illustration-start-->
 ## Example task
 
 Predict the day of first bloom of the common lilac given indirect observations
 (e.g. satellite data) and/or other indicators (e.g. sunshine and temperature).
 
 ![illustration_example_use_case](docs/illustration.png)
-<!--illustration-end-->
+<!--intro-end-->
 
-## Usage
-<!--usage-start-->
-You can run `springtime` as a command-line tool in a terminal or use it as a python library e.g. in a Jupyter notebook. Below, we explain both CLI and API.
-<!--usage-end-->
 
-<!--recipe-start-->
-### CLI to run recipes
-
-The main component of `springtime` command-line is the recipe (scientific
-workflow). A recipe is a file with `yaml` extension that includes a set of
-instructions to reproduce a certain result. Recipes are written in a nice and
-readable format,
-e.g.
-
-```yaml
-datasets:
-  npn_obs:
-    dataset: RNPN
-    species_ids:
-      functional_type: "Deciduous broadleaf" # multiple species
-    phenophase_ids:
-        name: breaking leaf buds
-    years: [2015, 2020]
-    area:
-      name: Washington
-      bbox:
-        [
-          -124.08406940413612,
-          45.50277198520317,
-          -117.39620059586387,
-          49.99938001479683,
-        ]
-  daymet:
-    dataset: daymet_multiple_points
-    points:
-      source: npn_obs
-    years: [2015, 2020]
-    variables:
-      - tmin
-      - tmax
-    resample:
-      frequency: month
-      operator: median
-dropna: True
-experiment:
-  experiment_type: regression  # --> pycaret.regression.RegressionExperiment
-  setup:
-    ... # setup of the experiment
-  init_kwargs:
-    ... # intial arguments for models
-  compare_models:
-    include:
-      - 'lr'  # linear regression
-      - 'rf'  # random forest regressor
-      - 'sklearn.svm.SVR'
-      - 'interpret.glassbox.ExplainableBoostingRegressor'
-    cross_validation: true
-    n_select: 2
-  plots:
-    - error
-    - residuals
-```
-
-Such a recipe can then be executed with `springtime` command in a terminal:
-
-```bash
-springtime model_comparison_usecase.yaml
-```
-
-We provide several "recipes" for running
-[experiments](https://springtime.readthedocs.io/en/latest/experiments/).
-<!--recipe-end-->
-
-<!--api-start-->
-### Python API
-
-Springtime is written in Python (with parts in R) and can also be used in an
-interactive (IPython/Jupyter) session. For example:
-
-#### Downloading data
-
-```Python
-from springtime.datasets.PEP725Phenor import PEP725Phenor
-dataset = PEP725Phenor(species='Syringa vulgaris')
-dataset.download()
-df = dataset.load()
-```
-
-We provide several notebooks for downloading data from various sources.
-See "Datasets"
-[documentation](https://springtime.readthedocs.io/en/latest/datasets/).
-<!--api-end-->

--- a/README.md
+++ b/README.md
@@ -27,52 +27,9 @@ tool in a terminal or use it as a Python library e.g. in a Jupyter notebook.
 
 <!--intro-end-->
 
-[Documentation](https://springtime.readthedocs.io/)
+For more information and instruction, please refer to the
+[documentation](https://springtime.readthedocs.io/)
 
-<!--installation-start-->
-## Requirements
-
-This project requires python and R. To simplify installation of the (indirect) R
-depencencies you can create a Anaconda environment using [Mamba
-forge](https://github.com/conda-forge/miniforge#mambaforge) from our environment file:
-
-```shell
-curl -o environment.yml https://raw.githubusercontent.com/phenology/springtime/main/environment.yml
-mamba env create --file environment.yml
-conda activate springtime
-```
-
-## Install Python package with dependencies
-
-Once you have python and R, to install springtime in your current environment,
-type
-
-```bash
-pip install git+https://github.com/phenology/springtime.git
-```
-
-## Install R dependencies
-
-Some datasets use [R](https://www.r-project.org/) libraries. The R dependencies
-can be installed with
-
-```bash
-Rscript -e 'devtools::install_github("bluegreen-labs/phenor", upgrade="never")'
-Rscript -e 'devtools::install_github("ropensci/rppo", upgrade="never")'
-Rscript -e 'install.packages(c("daymetr", "MODISTools", "phenocamr", "rnpn"), repos = "http://cran.us.r-project.org")'
-```
-
-
-## Verify installation
-
-```bash
-python -m rpy2.situation
-> ...
-> Calling `R RHOME`: /home/peter/miniconda3/envs/springtime/lib/R
-> Environment variable R_LIBS_USER: None
-> ...
-```
-<!--installation-end-->
 
 <!--illustration-start-->
 ## Example task

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -140,10 +140,11 @@ The docker image is hosted on [GitHub Container Registry
 You need to setup a personal access token following the instructions
 [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
 
-Then create a new tag and push the image to GHCR:
+Then build and push the image to GHCR:
 
 ```bash
-docker tag springtime ghcr.io/phenology/springtime:latest
+# In the root of the repository
+docker build -t ghcr.io/phenology/springtime:latest .
 docker push ghcr.io/phenology/springtime:latest
 ```
 

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -132,6 +132,21 @@ hatch run mkdocs serve
 hatch run mkdocs build --clean --strict
 ```
 
+## Docker build
+
+The docker image is hosted on [GitHub Container Registry
+(GHCR)](https://github.com/phenology/springtime/pkgs/container/springtime).
+
+You need to setup a personal access token following the instructions
+[here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
+
+Then create a new tag and push the image to GHCR:
+
+```bash
+docker tag springtime ghcr.io/phenology/springtime:latest
+docker push ghcr.io/phenology/springtime:latest
+```
+
 ## Contributing guidelines
 
 We welcome contributions from everyone. Please use our [GitHub issue

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,3 @@ SPDX-License-Identifier: Apache-2.0
    start="<!--intro-start-->"
    end="<!--intro-end-->"
 %}
-{%
-   include-markdown "../README.md"
-   start="<!--illustration-start-->"
-   end="<!--illustration-end-->"
-%}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -91,27 +91,27 @@ You can use the docker image in two ways. The following command will start a
 jupyter lab instance in which the springtime environment is installed:
 
 ```bash
-docker run --rm -it -p 8888:8888 -v "${PWD}":/home/jovyan/work springtime
+docker run --rm -it -p 8888:8888 -v "${PWD}":/home/jovyan/work ghcr.io/phenology/springtime:latest
 ```
 
 Alternatively, you can use the docker image to use the springtime command on
 your terminal:
 
 ```bash
-docker run --rm springtime springtime --help
+docker run --rm ghcr.io/phenology/springtime:latest springtime --help
 ```
 
 You could also set an alias like so:
 
 ```bash
 # By setting this alias
-alias springtime="docker run --rm springtime springtime"
+alias springtime="docker run --rm ghcr.io/phenology/springtime:latest springtime"
 
 # you can now run
 springtime --help
 
 # which will effectively execute
-docker run --rm springtime springtime --help
+docker run --rm ghcr.io/phenology/springtime:latest springtime --help
 ```
 
 As such, you can effectively use the docker version of springtime exactly like
@@ -122,10 +122,10 @@ you would use a local installation.
 Essentially, the commands above can be split into a few parts:
 
 ```
-docker run <OPTIONS> springtime <COMMAND>
+docker run <OPTIONS> ghcr.io/phenology/springtime:latest <COMMAND>
 ```
 
-The core command `docker run springimte` starts a container based on the
+The core command `docker run ghcr.io/phenology/springtime:latest` starts a container based on the
 `springtime` image you just pulled. The `--rm` option makes sure it is deleted
 again after it is done executing `<COMMAND>`. The default command is to start a
 jupyter lab instance, so that's what happens if you don't specify `<COMMAND>`.
@@ -144,11 +144,10 @@ simply executing and exiting. Thus container will terminate once you terminate
 your jupyter lab session.
 
 Additional options may be added to the docker command as well. For example, to
-run on a macbook, we had to use `--platform linux/amd64` and specify the full
-path to the container, instead of just the name:
+run on a macbook, we had to add `--platform linux/amd64`:
 
 ```
-docker run --rm  ghcr.io/phenology/springtime springtime --help
+docker run --rm --platform linux/amd64 ghcr.io/phenology/springtime springtime --help
 ```
 
 Be aware that docker containers can consume significant resources on your

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -65,8 +65,12 @@ pip install git+https://github.com/phenology/springtime.git
 An alternative way to use springtime is via docker. We have prepared a docker
 image that can be found
 [here](https://github.com/phenology/springtime/pkgs/container/springtime). This
-image contains the same installation as detailed above, with everything already
-installed for you. To use it, you need to have docker installed on your system.
+image is based on [the official jupyter docker
+stack](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-r-notebook)
+with R already installed. On top of that, we have already installed springtime
+with all its dependencies.
+
+To use it, you need to have docker installed on your system.
 
 Official instructions for installing docker desktop can be found
 [here](https://docs.docker.com/engine/install/). Alternatively, many third-party
@@ -81,34 +85,70 @@ docker pull ghcr.io/phenology/springtime:latest
 
 After the download completes, the image should be listed when you type `docker images`.
 
-Now, you should be able to test your installation of springtime with:
+### Using the docker image
+
+You can use the docker image in two ways. The following command will start a
+jupyter lab instance in which the springtime environment is installed:
 
 ```bash
-docker run -v $PWD:/repo -v /home/peter/springtime/data:/tmp --rm springtime springtime --help
+docker run --rm -it -p 8888:8888 -v "${PWD}":/home/jovyan/work springtime
 ```
 
-### Understanding the docker command
+Alternatively, you can use the docker image to use the springtime command on
+your terminal:
 
-Essentially, the command above can be split into a few parts:
+```bash
+docker run --rm springtime springtime --help
+```
+
+You could also set an alias like so:
+
+```bash
+# By setting this alias
+alias springtime="docker run --rm springtime springtime"
+
+# you can now run
+springtime --help
+
+# which will effectively execute
+docker run --rm springtime springtime --help
+```
+
+As such, you can effectively use the docker version of springtime exactly like
+you would use a local installation.
+
+### Customizing the docker command to your needs
+
+Essentially, the commands above can be split into a few parts:
 
 ```
 docker run <OPTIONS> springtime <COMMAND>
 ```
 
-`docker run springimte` starts a container based on the `springtime` image you just pulled.
-The `--rm` option makes sure it is deleted again after it is done executing
-`<COMMAND>`. The `-v $PWD:/repo` tells docker to make your current working
-directory (on your own system) available to the docker container. Inside the
-container this directory will be available as `/repo`.
+The core command `docker run springimte` starts a container based on the
+`springtime` image you just pulled. The `--rm` option makes sure it is deleted
+again after it is done executing `<COMMAND>`. The default command is to start a
+jupyter lab instance, so that's what happens if you don't specify `<COMMAND>`.
+Above, we executed the command `springtime --help`.
 
-TODO: specify an additional mountpoint for data directory.
+The `-v "${PWD}":/home/jovyan/work` tells docker to make your current working
+directory (on your own system) available to the docker container. Inside the
+container this directory will be available as `/home/jovyan/work`, i.e. the
+`work` folder you see by default in jupyter lab. Changes inside this folder will
+remain available on your host system. Changes in any other directory will be
+lost when the container is destroyed. Note that you can mount multiple
+directories in this way.
+
+The `-it` makes it possible to interact with the running program, intead of
+simply executing and exiting. Thus container will terminate once you terminate
+your jupyter lab session.
 
 Additional options may be added to the docker command as well. For example, to
 run on a macbook, we had to use `--platform linux/amd64` and specify the full
 path to the container, instead of just the name:
 
 ```
-docker run -v $PWD:/repo --rm  ghcr.io/phenology/springtime springtime
+docker run --rm  ghcr.io/phenology/springtime springtime --help
 ```
 
 Be aware that docker containers can consume significant resources on your
@@ -116,37 +156,12 @@ system. Make sure that they're always properly removed when you're ready. You
 can run `docker ps -a` to see all containers lingering around on your system,
 and you can remove them with `docker rm <ID OR NAME>`.
 
-### Running springtime through docker
+### Note: tmp/data
 
-The `<COMMAND>` part is similar to how you would use springtime on the command
-line in the rest of the documentation. That means that the following alias would
-make the "docker powered" version act as a drop-in replacement of the "local" springtime.
-
-```bash
-# By setting this alias
-alias springtime="docker run -v $PWD:/repo --rm springtime springtime"
-
-# you can now run
-springtime --help
-
-# and it will be the same as
-docker run -v $PWD:/repo --rm springtime springtime --help
-```
-
-### Starting jupyter lab or IPython from the container
-
-To start an interactive python session, you can run
-
-```bash
-docker run -v $PWD:/repo --rm -it springtime ipython
-```
-
-The `-it` makes it possible to interact with the running program, intead of
-simply executing and exiting. Note that the container will terminate once you
-terminate your ipython session.
-
-TODO: add jupyter lab to container so we can use that as well
-
+By default, currently, springtime stores any data or output in /tmp/data. That
+means it will be lost when the docker container is destroyed. To persist it, for
+now, move it to the work folder. We are planning to add additional configuration
+that should make specification of the output or data directories more flexible.
 
 ## Install on CRIB or other managed JupyterHub service
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,11 +6,147 @@ SPDX-License-Identifier: Apache-2.0
 
 # Getting started
 
-{%
-   include-markdown "../README.md"
-   start="<!--installation-start-->"
-   end="<!--installation-end-->"
-%}
+This project requires python and R. We provide two ways to simplify the
+installation: [using mamba](#installing-with-mamba) and [using docker](#installing-with-docker).
+
+## Installing with mamba
+
+### Create environment
+
+Create a new Anaconda environment using [Mamba
+forge](https://github.com/conda-forge/miniforge#mambaforge) and our environment
+file:
+
+```shell
+curl -o environment.yml https://raw.githubusercontent.com/phenology/springtime/main/environment.yml
+mamba env create --file environment.yml
+conda activate springtime
+```
+
+This environment contains python, R, and some of the dependencies of our project
+that are available on conda-forge.
+
+You can verify that the environment is configured correctly by running
+
+```bash
+python -m rpy2.situation
+```
+
+If everything is okay, it should print something like:
+
+```bash
+...
+Calling `R RHOME`: /home/peter/miniconda3/envs/springtime/lib/R
+Environment variable R_LIBS_USER: None
+...
+```
+
+### Install R dependencies
+
+Additional [R](https://www.r-project.org/) libraries that are not available from
+conda-forge need to be added manuallyL
+
+```bash
+Rscript -e 'devtools::install_github("bluegreen-labs/phenor", upgrade="never")'
+Rscript -e 'devtools::install_github("ropensci/rppo", upgrade="never")'
+Rscript -e 'install.packages(c("daymetr", "MODISTools", "phenocamr", "rnpn"), repos = "http://cran.us.r-project.org")'
+```
+
+### Install springtime
+
+Now, you can install springtime along with it's (python) dependencies like so:
+
+```bash
+pip install git+https://github.com/phenology/springtime.git
+```
+
+## Installing with docker
+
+An alternative way to use springtime is via docker. We have prepared a docker
+image that can be found
+[here](https://github.com/phenology/springtime/pkgs/container/springtime). This
+image contains the same installation as detailed above, with everything already
+installed for you. To use it, you need to have docker installed on your system.
+
+Official instructions for installing docker desktop can be found
+[here](https://docs.docker.com/engine/install/). Alternatively, many third-party
+instructions can be found online to install docker without docker
+desktop, for example in WSL.
+
+Once you have docker, you can pull the springtime image using
+
+```bash
+docker pull ghcr.io/phenology/springtime:latest
+```
+
+After the download completes, the image should be listed when you type `docker images`.
+
+Now, you should be able to test your installation of springtime with:
+
+```bash
+docker run -v $PWD:/repo -v /home/peter/springtime/data:/tmp --rm springtime springtime --help
+```
+
+### Understanding the docker command
+
+Essentially, the command above can be split into a few parts:
+
+```
+docker run <OPTIONS> springtime <COMMAND>
+```
+
+`docker run springimte` starts a container based on the `springtime` image you just pulled.
+The `--rm` option makes sure it is deleted again after it is done executing
+`<COMMAND>`. The `-v $PWD:/repo` tells docker to make your current working
+directory (on your own system) available to the docker container. Inside the
+container this directory will be available as `/repo`.
+
+TODO: specify an additional mountpoint for data directory.
+
+Additional options may be added to the docker command as well. For example, to
+run on a macbook, we had to use `--platform linux/amd64` and specify the full
+path to the container, instead of just the name:
+
+```
+docker run -v $PWD:/repo --rm  ghcr.io/phenology/springtime springtime
+```
+
+Be aware that docker containers can consume significant resources on your
+system. Make sure that they're always properly removed when you're ready. You
+can run `docker ps -a` to see all containers lingering around on your system,
+and you can remove them with `docker rm <ID OR NAME>`.
+
+### Running springtime through docker
+
+The `<COMMAND>` part is similar to how you would use springtime on the command
+line in the rest of the documentation. That means that the following alias would
+make the "docker powered" version act as a drop-in replacement of the "local" springtime.
+
+```bash
+# By setting this alias
+alias springtime="docker run -v $PWD:/repo --rm springtime springtime"
+
+# you can now run
+springtime --help
+
+# and it will be the same as
+docker run -v $PWD:/repo --rm springtime springtime --help
+```
+
+### Starting jupyter lab or IPython from the container
+
+To start an interactive python session, you can run
+
+```bash
+docker run -v $PWD:/repo --rm -it springtime ipython
+```
+
+The `-it` makes it possible to interact with the running program, intead of
+simply executing and exiting. Note that the container will terminate once you
+terminate your ipython session.
+
+TODO: add jupyter lab to container so we can use that as well
+
 
 ## Install on CRIB or other managed JupyterHub service
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,18 +4,91 @@ SPDX-FileCopyrightText: 2023 Springtime authors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-{%
-   include-markdown "../README.md"
-   start="<!--usage-start-->"
-   end="<!--usage-end-->"
-%}
-{%
-   include-markdown "../README.md"
-   start="<!--recipe-start-->"
-   end="<!--recipe-end-->"
-%}
-{%
-   include-markdown "../README.md"
-   start="<!--api-start-->"
-   end="<!--api-end-->"
-%}
+# Usage
+
+You can run `springtime` as a command-line tool in a terminal or use it as a
+python library e.g. in a Jupyter notebook. Below, we explain both CLI and API.
+
+## CLI to run recipes
+
+The main component of `springtime` command-line is the recipe (scientific
+workflow). A recipe is a file with `yaml` extension that includes a set of
+instructions to reproduce a certain result. Recipes are written in a nice and
+readable format,
+e.g.
+
+```yaml
+datasets:
+  npn_obs:
+    dataset: RNPN
+    species_ids:
+      functional_type: "Deciduous broadleaf" # multiple species
+    phenophase_ids:
+        name: breaking leaf buds
+    years: [2015, 2020]
+    area:
+      name: Washington
+      bbox:
+        [
+          -124.08406940413612,
+          45.50277198520317,
+          -117.39620059586387,
+          49.99938001479683,
+        ]
+  daymet:
+    dataset: daymet_multiple_points
+    points:
+      source: npn_obs
+    years: [2015, 2020]
+    variables:
+      - tmin
+      - tmax
+    resample:
+      frequency: month
+      operator: median
+dropna: True
+experiment:
+  experiment_type: regression  # --> pycaret.regression.RegressionExperiment
+  setup:
+    ... # setup of the experiment
+  init_kwargs:
+    ... # intial arguments for models
+  compare_models:
+    include:
+      - 'lr'  # linear regression
+      - 'rf'  # random forest regressor
+      - 'sklearn.svm.SVR'
+      - 'interpret.glassbox.ExplainableBoostingRegressor'
+    cross_validation: true
+    n_select: 2
+  plots:
+    - error
+    - residuals
+```
+
+Such a recipe can then be executed with `springtime` command in a terminal:
+
+```bash
+springtime model_comparison_usecase.yaml
+```
+
+We provide several "recipes" for running
+[experiments](https://springtime.readthedocs.io/en/latest/experiments/).
+
+## Python API
+
+Springtime is written in Python (with parts in R) and can also be used in an
+interactive (IPython/Jupyter) session. For example:
+
+### Downloading data
+
+```Python
+from springtime.datasets.PEP725Phenor import PEP725Phenor
+dataset = PEP725Phenor(species='Syringa vulgaris')
+dataset.download()
+df = dataset.load()
+```
+
+We provide several notebooks for downloading data from various sources.
+See "Datasets"
+[documentation](https://springtime.readthedocs.io/en/latest/datasets/).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -73,7 +73,7 @@ springtime model_comparison_usecase.yaml
 ```
 
 We provide several "recipes" for running
-[experiments](https://springtime.readthedocs.io/en/latest/experiments/).
+[experiments](https://springtime.readthedocs.io/en/latest/recipes/).
 
 ## Python API
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,8 @@ dependencies:
   - pip!=21.3
   - python==3.10
   - hatch
+  - git
+  - rpy2
   # R dependencies
   - r-base >=4.2
   # - r-BayesianTools   # not in any anconda channel

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
   - r
 dependencies:
   - pip!=21.3
-  # - python==3.10
+  # - python==3.10  # breaks docker build; rather set outside environment
   - hatch
   - git
   - rpy2

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ channels:
   - r
 dependencies:
   - pip!=21.3
-  - python==3.10
+  # - python==3.10
   - hatch
   - git
   - rpy2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,11 +10,8 @@ nav:
   - Home:
       - About: index.md
       - Getting started: setup.md
-  - User Guide:
-      - Getting started:
-          - Installation: setup.md
-          - Usage: usage.md
-      - Recipes: recipes.md
+      - Usage: usage.md
+      - Example recipes: recipes.md
   - Datasets:
       - Data sources and existing tools: datasets.md
       - Field observations:

--- a/src/springtime/recipes/model_comparison_usecase.yaml
+++ b/src/springtime/recipes/model_comparison_usecase.yaml
@@ -58,7 +58,7 @@ experiment:
     fold_shuffle: true
     session_id: 123  # control randomness for reproducibility
     index: False # Exclude year and geomentry columns
-    # categorical_features: 
+    # categorical_features:
     #   - site_id
     # max_encoding_ohe: 250
 
@@ -85,7 +85,7 @@ experiment:
       - 'sklearn.svm.SVR'
       - 'interpret.glassbox.ExplainableBoostingRegressor'
       - merf.MERF  # Must be instantiated before passing to pycaret; how to specify args?
-    # fit_kwargs are given to each estimator.fit method 
+    # fit_kwargs are given to each estimator.fit method
     # so if estimator does not understand it crashes and is skipped.
     fit_kwargs:
       MERF:
@@ -103,7 +103,7 @@ experiment:
   #       fixed_effects: ['Lai_500m_12']  # "the rest" after removing cluster, random effects, and target columns
   #       random_effects: [ "tmin_2", "tmin_3", "tmin_3"]
   #       cluster_column: "latitude"
-    
+
   plots:
     - error
     - residuals


### PR DESCRIPTION
This PR adds instuctions on installing springtime with docker.

Additionally:

- Changes the docker image base to [jupyter/r-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-r-notebook)
- Migrate install & usage instructions from readme to docs