### PR TITLE
Fix installation of springtime extra packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN Rscript -e 'devtools::install_github("ropensci/rppo", upgrade="never")'
 RUN Rscript -e 'install.packages(c("daymetr", "MODISTools", "phenocamr", "rnpn"), repos = "http://cran.us.r-project.org")'
 
 # Install springtime + bonus packages
-RUN pip install springtime[extra]
+RUN pip install springtime[extras]
 
 # Editable install of cloned repo
 # WORKDIR /home/jovyan


### PR DESCRIPTION
Small typo in the Dockerfile, which causes Pycaret and pyPhenology to be missing from the Docker image. I was not aware that `pip` does not complain if the required extra does not exist.   