### PR TITLE
Use python=3.10 in installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,7 +22,7 @@ You need to have mamba/conda available on your system. To create a new environme
 and activate it, run
 
 ```bash
-mamba create --name springtime python="3.11"
+mamba create --name springtime python="3.10"
 mamba activate springtime
 ```
 


### PR DESCRIPTION
Installing `pycaret[models]` with `pip` fails with python=3.11 on OS X (x86_64)