### PR TITLE
Docker build GH action

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
-        context: image
         push: true
         tags: |
           ghcr.io/${{ env.REPO }}:${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue with Docker image GitHub action - a non-existent path was provided as context.
+
 ## [0.2.2] - 2024-05-24
 
 ### Added


### PR DESCRIPTION
The path to a non-existent subdirectory was provided as context to build the image.  My bad, I have taken the action from [another repo](https://github.com/phenology/2024-lorentz-workshop-jupyterhub) and didn't adapt it well - sorry! 